### PR TITLE
fix: update Vite env vars to resolve production auth requests [NSOC'26}

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone [https://github.com/your-username/crop-advisor.git](https://github.com
 npm install
 
 # Set up environment variables
-echo "REACT_APP_WEATHER_API_KEY=your_key_here" > .env
+echo "VITE_WEATHER_API_KEY=your_key_here" > .env
 
 # Launch the dashboard
 npm start

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,12 @@
 # Weather API
-REACT_APP_WEATHER_API_KEY=your_openweathermap_api_key_here
+VITE_WEATHER_API_KEY=your_openweathermap_api_key_here
 
 # Backend API
-REACT_APP_API_URL=http://localhost:5000
+VITE_API_URL=http://localhost:5000
 
 # Socket.IO
-REACT_APP_SOCKET_URL=http://localhost:5000
+VITE_SOCKET_URL=http://localhost:5000
 
 # Google OAuth (if using Google login)
-REACT_APP_GOOGLE_CLIENT_ID=your_google_client_id_here
+VITE_GOOGLE_CLIENT_ID=your_google_client_id_here
 VITE_GEMINI_API_KEY=your_gemini_api_key_here

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -15,7 +15,7 @@ export const AuthProvider = ({ children }) => {
     const [token, setToken] = useState(localStorage.getItem('token'));
     const [loading, setLoading] = useState(false); // Start with false to prevent hanging
 
-    const API_URL = import.meta.env.REACT_APP_API_URL || 'http://localhost:5000';
+    const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
     // Fetch user profile on mount if token exists
     useEffect(() => {


### PR DESCRIPTION
#  Fix: Resolve deployed authentication failure caused by incorrect Vite environment variables

## Problem
The deployed frontend was making authentication requests to:

http://localhost:5000/api/auth/...

This caused **Sign Up / Login** to fail in production with:

- Failed to fetch  
- net::ERR_CONNECTION_REFUSED

Since `localhost` only works during local development.

---

## Root Cause
The frontend uses **Vite**, but environment variables were using the `REACT_APP_` prefix.

In Vite projects, frontend environment variables must use the `VITE_` prefix.

Because of this, the production API URL was not being loaded correctly, and the app fell back to `localhost:5000`.

---

## Changes Made

### Updated `AuthContext.jsx`
- Replaced:
  `import.meta.env.REACT_APP_API_URL`

- With:
  `import.meta.env.VITE_API_URL`

### Updated `frontend/.env.example`
- `REACT_APP_API_URL` → `VITE_API_URL`
- `REACT_APP_SOCKET_URL` → `VITE_SOCKET_URL`
- `REACT_APP_WEATHER_API_KEY` → `VITE_WEATHER_API_KEY`
- `REACT_APP_GOOGLE_CLIENT_ID` → `VITE_GOOGLE_CLIENT_ID`

### Updated `README.md`
- Corrected environment variable names to match Vite format.

---

## What Maintainers Need To Do After Merge

Update frontend environment variables in Vercel:

```env
VITE_API_URL=<your-backend-url>
VITE_SOCKET_URL=<your-backend-url>
VITE_WEATHER_API_KEY=<your-key>
VITE_GOOGLE_CLIENT_ID=<your-client-id>
VITE_GEMINI_API_KEY=<your-key>
```
---
Then redeploy the frontend.


 Expected Result
-Sign Up / Login should work on the deployed site.
-Requests should go to the configured backend URL instead of localhost.

Closes #32